### PR TITLE
Use alpine base image for reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.3
+FROM node:6.10.3-alpine
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
### Purpose
To reduce the size of the final image use Alpine linux. This also makes the build time faster as the base image to pull is a lot smaller.

### Notes
Size reduction of overall image for `0.0.12` drops dramatically:
```
$ docker images bufferapp/lookerbot
REPOSITORY            TAG                 IMAGE ID            CREATED             SIZE
bufferapp/lookerbot   0.0.12-alpine       1823d5ba49fd        16 hours ago        166 MB
bufferapp/lookerbot   0.0.11              444b32141b40        16 hours ago        742 MB
bufferapp/lookerbot   0.0.12              4c3fb31f21a3        17 hours ago        773 MB
```

When comparing the compressed image size [on Docker hub](https://hub.docker.com/r/bufferapp/lookerbot/tags/) for `0.0.12`, the change is from 291MB to 48MB. Performance is the same when compared to full Debian-based image.