### PR TITLE
Copy dashboard element query before mutating it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/lib/repliers/dashboard_query_runner.ts
+++ b/lib/repliers/dashboard_query_runner.ts
@@ -27,14 +27,16 @@ export class DashboardQueryRunner extends QueryRunner {
       throw new Error("Dashboards with more than one element aren't currently supported for Slack commands.")
     }
 
+    const copy = (obj: any) => JSON.parse(JSON.stringify(obj))
+
     for (const element of elements) {
 
       let queryDef: IQuery
 
       if (element.query) {
-        queryDef = element.query
+        queryDef = copy(element.query)
       } else if (element.look) {
-        queryDef = element.look.query
+        queryDef = copy(element.look.query)
       } else {
         throw new Error("Dashboard Element has no Look or Query.")
       }


### PR DESCRIPTION
This was causing the previous run's filters to stick around.

closes https://github.com/looker/lookerbot/issues/116
