### PR TITLE
Add EXPOSE instruction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ WORKDIR /app
 RUN yarn install
 
 ENTRYPOINT ["yarn", "start"]
+
+EXPOSE 3333


### PR DESCRIPTION
This change adds a [Docker EXPOSE instruction](https://docs.docker.com/engine/reference/builder/#expose) to announce that the container listens on port 3333. This chance was necessary for me to deploy Lookerbot on AWS Elastic Beanstalk. 

Without the EXPOSE instruction, Elastic Beanstalk throws a ["No EXPOSE directive found in Dockerfile, abort deployment" error](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/troubleshooting-docker.html)

Elastic Beanstalk uses this instruction to map external requests to port 80 to the exposed port on the docker container. 

Note that this isn't in sync with the `PORT` environment variable. I'd imagine this could be resolved, but I'm not sure the best way to handle it given the various deployment options available for this project.

Happy to make any changes needed to merge; suggestions welcome.

Cool project; thanks for all the great work!