### PR TITLE
Fix issue with uninitialized variable

### DIFF
--- a/src/repliers/dashboard_query_runner.ts
+++ b/src/repliers/dashboard_query_runner.ts
@@ -51,6 +51,7 @@ export class DashboardQueryRunner extends QueryRunner {
                    element.result_maker.filterables[0].listen) {
           element.result_maker!.filterables![0].listen.forEach((listen) => {
             if (this.filters[listen.dashboard_filter_name]) {
+              if (!queryDef.filters) { queryDef.filters = {} }
               queryDef.filters[listen.field] = this.filters[listen.dashboard_filter_name]
             }
           })


### PR DESCRIPTION
It's possible that `queryDef.filters` isn't initialized prior to using that property.  This just initializes if needed (much like line 44 above it).