### PR TITLE
add option to print tables as pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ There are a couple environment variables that can be used to tweak behavior:
 
 - `LOOKERBOT_DATA_ACTIONS_IN_MESSAGES` – Set this to `false` to disable making data action buttons available to Slack users.
 
+- `LOOKERBOT_PRINT_TABLES_AS_IMAGES` – Set this to `true` to handle tables as images instead of text mode.
+
 ##### (optional) Storage Services for Visualization Images
 
 ###### Amazon S3

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ const config = {
   npmPackage: require("./../package.json"),
   slackApiKey: process.env.SLACK_API_KEY,
   unsafeLocalDev: process.env.UNSAFE_LOCAL_DEV === "true",
+  showTablesAsImages: process.env.LOOKERBOT_PRINT_TABLES_AS_IMAGES === "true",
 }
 
 if (config.unsafeLocalDev) {

--- a/src/repliers/query_runner.ts
+++ b/src/repliers/query_runner.ts
@@ -5,6 +5,7 @@ import { SlackUtils } from "../slack_utils"
 import blobStores from "../stores/index"
 import { FancyReplier } from "./fancy_replier"
 import { SlackTableFormatter } from "./slack_table_formatter"
+import config from "../config";
 
 export class QueryRunner extends FancyReplier {
 
@@ -100,7 +101,7 @@ export class QueryRunner extends FancyReplier {
   protected async runQuery(query: IQuery) {
     const visType: string = query.vis_config && query.vis_config.type ? query.vis_config.type : "table"
 
-    if (visType === "table" || visType === "looker_single_record" || visType === "single_value") {
+    if (((visType === "table" && !config.showTablesAsImages) || visType === "looker_single_record" || visType === "single_value") {
       try {
         const result = await this.replyContext.looker.client.getAsync(
           `queries/${query.id}/run/unified`,

--- a/src/repliers/query_runner.ts
+++ b/src/repliers/query_runner.ts
@@ -101,7 +101,7 @@ export class QueryRunner extends FancyReplier {
   protected async runQuery(query: IQuery) {
     const visType: string = query.vis_config && query.vis_config.type ? query.vis_config.type : "table"
 
-    if (((visType === "table" && !config.showTablesAsImages) || visType === "looker_single_record" || visType === "single_value") {
+    if ((visType === "table" && !config.showTablesAsImages) || visType === "looker_single_record" || visType === "single_value") {
       try {
         const result = await this.replyContext.looker.client.getAsync(
           `queries/${query.id}/run/unified`,


### PR DESCRIPTION
the basic format options offered by stack are limiting the table visualization. 
Using images is a easy workarround.