### PR TITLE
Add workspace membership validation for Slack Enterprise users

### DIFF
--- a/src/services/slack_service.ts
+++ b/src/services/slack_service.ts
@@ -180,7 +180,7 @@ export class SlackService extends Service {
         const user = response.user
         if (!config.enableGuestUsers && (user.is_restricted || user.is_ultra_restricted)) {
           reply(`Sorry @${user.name}, as a guest user you're not able to use this command.`)
-        } else if (!config.enableSharedWorkspaces && user.team_id !== this.defaultBot.team_info.id) {
+        } else if (!config.enableSharedWorkspaces && user.team_id !== this.defaultBot.team_info.id && !(user.teams && user.teams.includes(this.defaultBot.team_info.id))) {
           reply(`Sorry @${user.name}, as a user from another workspace you're not able to use this command.`)
         } else if (user.is_stranger) {
           reply(`Sorry @${user.name}, as a user from another workspace you're not able to use this command.`)


### PR DESCRIPTION
Fixes https://github.com/looker/lookerbot/issues/184

This PR adds an additional check on the `user.teams` array to ensure a Slack Enterprise user is not part of a workspace before bailing out with the error message.

# Test plan

As there appear to be no tests for this project, I manually made these changes to the lookerbot service we're running internally, restarted the service, and confirmed I - as an Slack Enterprise user - can use Lookerbot again to query data.