### PR TITLE
Allow user to pass multiple filters to custom slash commands / Show all filters in help menu

### DIFF
--- a/src/commands/custom_command.ts
+++ b/src/commands/custom_command.ts
@@ -21,9 +21,14 @@ export class CustomCommand extends Command {
 
       const filters: {[key: string]: string} = {}
       const dashboardFilters = dashboard.dashboard_filters || dashboard.filters
-      for (const filter of dashboardFilters) {
-        filters[filter.name] = query
-      }
+      const params = query.split(";")
+      const usedFilters = dashboardFilters.slice(0, params.length)
+      var iterator = params.values()
+
+      usedFilters.forEach(function (value: any) {
+        filters[value.name] = iterator.next().value
+      })
+
       const runner = new DashboardQueryRunner(context, matchedCommand.dashboard, filters)
       runner.start()
 

--- a/src/looker.ts
+++ b/src/looker.ts
@@ -104,7 +104,11 @@ export class Looker {
 
         const dashboardFilters = dashboard.dashboard_filters || dashboard.filters
         if (dashboardFilters && dashboardFilters.length > 0) {
-          command.helptext = `<${dashboardFilters[0].title.toLowerCase()}>`
+          let descText = ""
+          dashboardFilters.forEach(function (value: any) {
+            descText += `<${value.title.toLowerCase()}>`
+          })
+          command.helptext = descText
         }
 
         Looker.customCommands[command.name] = command


### PR DESCRIPTION
When calling a dashboard using custom slash commands, lookerbot only allowed for the dashboard to have a single filter. Attempting to call a dashboard with multiple filters and using only one parameter would cause the parameter to be applied to both filters, even if it was only relevant to one. (see below call and resulting applied filters). 

<img width="197" alt="Slack: Single parameter, multiple filters" src="https://user-images.githubusercontent.com/78392163/124203797-5f119400-da92-11eb-9006-6aab70a6f4a4.png">

![Before: Single parameter, multiple filters](https://user-images.githubusercontent.com/78392163/124203808-6638a200-da92-11eb-80ec-d73626fa99a9.png)

Passing multiple parameters to a multi-filter dashboard would pass the literal entered string as a parameter to all filters, even if separated by a space or semicolon. 

![Before: Semicolon](https://user-images.githubusercontent.com/78392163/124203724-37bac700-da92-11eb-8a82-d55f134b0000.png)

Using a comma to separate them would lead to a logical "or" between the passed values, which was still applied to all filters. This would create an issue when filters have overlapping input spaces. 

![Before: Comma](https://user-images.githubusercontent.com/78392163/124203691-2376ca00-da92-11eb-84f1-d0e88abdc39b.png)

This PR enables users to pass multiple parameters to the slack command, which will be applied to the filters one by one in the order the filters are listed. The parameters should be separated by semicolons to distinguish between filters. The comma still works as a logical "or" within a given parameter. 

<img width="286" alt="Slack: Semicolon and Comma, multiple filters" src="https://user-images.githubusercontent.com/78392163/124204091-1b6b5a00-da93-11eb-96f2-8e380aac2a75.png">

![After: Semicolon and Comma, multiple filters](https://user-images.githubusercontent.com/78392163/124204132-405fcd00-da93-11eb-81a5-13a0e9063948.png)

If there are fewer parameters passed than available filters, all subsequent filters will have no parameter passed (i.e. no restriction). To leave an earlier parameter blank but pass a value to a later parameter, use a semicolon to separate but do not enter a value. 

<img width="199" alt="Slack: Blank parameter" src="https://user-images.githubusercontent.com/78392163/124204704-78b3db00-da94-11eb-9160-52e6d7c4e6b7.png">

![After: Blank parameter](https://user-images.githubusercontent.com/78392163/124204723-80737f80-da94-11eb-9bbc-c2298d0965a7.png)

The PR also makes changes to looker.ts to allow all filters to appear in the help menu in the order that parameters should be entered. 

<img width="252" alt="After: Help Menu" src="https://user-images.githubusercontent.com/78392163/124204258-8321a500-da93-11eb-98f7-7544b5956895.png">